### PR TITLE
Add frozen dataclasses to things

### DIFF
--- a/hsms/streamables/coin.py
+++ b/hsms/streamables/coin.py
@@ -1,5 +1,7 @@
 import io
 
+from dataclasses import dataclass
+
 from clvm.casts import int_from_bytes, int_to_bytes
 
 from hsms.atoms import streamable, uint64
@@ -9,6 +11,7 @@ from hsms.util.std_hash import std_hash
 from . import bytes32
 
 
+@dataclass(frozen=True)
 @streamable
 class Coin:
     """

--- a/hsms/streamables/coin_spend.py
+++ b/hsms/streamables/coin_spend.py
@@ -1,10 +1,12 @@
+from dataclasses import dataclass
+
 from .coin import Coin
 from .program import Program
 
 from hsms.atoms import streamable
 from hsms.util.clvm_serialization import transform_as_struct
 
-
+@dataclass(frozen=True)
 @streamable
 class CoinSpend:
     """


### PR DESCRIPTION
I'm not sure why it wasn't like this before, but I was trying to initialize a coin spend like so `CoinSpend(coin, puzzle, solution)` and it wasn't working, throwing the error `ValueError: got 1 and expected 3 args`.  Making this change fixed it for me.