### PR TITLE
Don't conditionally add path and sum hints

### DIFF
--- a/hsms/process/unsigned_spend.py
+++ b/hsms/process/unsigned_spend.py
@@ -34,11 +34,9 @@ class UnsignedSpend:
         ]
         as_clvm.append(("c", cs_as_clvm))
         sh_as_clvm = [_.as_program() for _ in self.sum_hints]
-        if sh_as_clvm:
-            as_clvm.append(("s", sh_as_clvm))
+        as_clvm.append(("s", sh_as_clvm))
         ph_as_clvm = [_.as_program() for _ in self.path_hints]
-        if ph_as_clvm:
-            as_clvm.append(("p", ph_as_clvm))
+        as_clvm.append(("p", ph_as_clvm))
         self_as_program = Program.to(as_clvm)
         return self_as_program
 


### PR DESCRIPTION
This was causing an error when trying to deserialize an unsigned spend that had no path hints.  This change fixed it.